### PR TITLE
Typo in variable errrorMsg => errorMsg

### DIFF
--- a/Intune.USB.Creator/Private/Get-AutopilotPolicy.ps1
+++ b/Intune.USB.Creator/Private/Get-AutopilotPolicy.ps1
@@ -60,7 +60,7 @@ function Get-AutopilotPolicy {
                 Remove-Module $_ -ErrorAction SilentlyContinue 3>$null
             }
         }
-        if ($errrorMsg) {
+        if ($errorMsg) {
             Write-Warning $errorMsg
         }
     }


### PR DESCRIPTION
Corrected typo of the variable `errorMsg` and added a newline to keep git happy.