### PR TITLE
Forcing Version of PWSH to 7.0.3

### DIFF
--- a/Intune.USB.Creator/Public/Publish-ImageToUSB.ps1
+++ b/Intune.USB.Creator/Public/Publish-ImageToUSB.ps1
@@ -97,9 +97,9 @@ function Publish-ImageToUSB {
         Invoke-RestMethod -Method Get -Uri $script:provisionUrl -OutFile "$($usb.drive):\scripts\Invoke-Provision.ps1"
         #endregion
         #region download and apply powershell 7 to usb
-        Write-Host "`nGrabbing PWSH 7.." -ForegroundColor Yellow
-        Invoke-RestMethod -Method Get -Uri 'https://aka.ms/install-powershell.ps1' -OutFile "$env:Temp\install-powershell.ps1"
-        . $env:Temp\install-powershell.ps1 -Destination "$($usb.drive):\scripts\pwsh"
+        Write-Host "`nGrabbing PWSH 7.0.3.." -ForegroundColor Yellow
+        Invoke-RestMethod -Method Get -Uri 'https://github.com/PowerShell/PowerShell/releases/download/v7.0.3/PowerShell-7.0.3-win-x64.zip' -OutFile "$env:Temp\pwsh7.zip"
+        Expand-Archive -path "$env:Temp\pwsh7.zip" -Destinationpath "$($usb.drive):\scripts\pwsh"
         #endregion download and apply powershell 7 to usb
         $completed = $true
     }

--- a/Intune.USB.Creator/ReleaseNotes.txt
+++ b/Intune.USB.Creator/ReleaseNotes.txt
@@ -1,3 +1,2 @@
 {{NewVersion}}
-  - Fixes issues with WinPE extraction. (Thanks to Peter C. for troubleshooting this one)
-  - Fixes issues with multiple autopilot policies not downloading properly.
+  - Forcing version of PowerShell to 7.0.3 to fix reported problems with WinPE & PowerShell 7.1


### PR DESCRIPTION
## Problem
When using Intune.USB.Creator module and installing latest build of PowerShell 7 problems launching external cli tools were reported.
## Fix
Specifying PowerShell 7.0.3 as the required build of PowerShell. This is the latest version that seems to work - I'll be raising a ticket with the PowerShell team, but for now, this will resolve #22