### PR TITLE
Driver bootstrapping now added to solution 🍻🍻🍻

### DIFF
--- a/Intune.USB.Creator/Private/Set-USBPartiton.ps1
+++ b/Intune.USB.Creator/Private/Set-USBPartiton.ps1
@@ -19,7 +19,7 @@ function Set-USBPartition {
         }
         Start-Sleep -Seconds 3
         Write-Host "Creating New Partions" -ForegroundColor Cyan
-        $usbClass.drive = (New-Partition -DiskNumber $diskNum -Size 2GB -AssignDriveLetter | Format-Volume -FileSystem FAT32 -NewFileSystemLabel WINPE -Confirm:$false -Force).DriveLetter
+        $usbClass.drive = (New-Partition -DiskNumber $diskNum -Size 3GB -AssignDriveLetter | Format-Volume -FileSystem FAT32 -NewFileSystemLabel WINPE -Confirm:$false -Force).DriveLetter
         $usbClass.drive2 = (New-Partition -DiskNumber $diskNum -UseMaximumSize -AssignDriveLetter | Format-Volume -FileSystem NTFS -NewFileSystemLabel Images -Confirm:$false -Force).DriveLetter
         $usbClass
     }

--- a/Intune.USB.Creator/Public/Publish-ImageToUSB.ps1
+++ b/Intune.USB.Creator/Public/Publish-ImageToUSB.ps1
@@ -92,6 +92,10 @@ function Publish-ImageToUSB {
             Write-ToUSB -Path "$($usb.downloadPath)\AutopilotConfigurationFile.json" -Destination "$($usb.drive):\scripts\"
         }
         #endregion
+        #region Create drivers folder
+        Write-Host "`nSetting up folder structures for Drivers.." -ForegroundColor Yellow -NoNewline
+        New-Item -Path "$($usb.drive2):\Drivers" -ItemType Directory -Force | Out-Null
+        #endregion
         #region download provision script and install to usb
         Write-Host "`nGrabbing provision script from GitHub.." -ForegroundColor Yellow
         Invoke-RestMethod -Method Get -Uri $script:provisionUrl -OutFile "$($usb.drive):\scripts\Invoke-Provision.ps1"

--- a/Intune.USB.Creator/ReleaseNotes.txt
+++ b/Intune.USB.Creator/ReleaseNotes.txt
@@ -1,2 +1,2 @@
 {{NewVersion}}
-  - Forcing version of PowerShell to 7.0.3 to fix reported problems with WinPE & PowerShell 7.1
+  - Updated Invoke-Provision to allow driver bootstrapping. Should allow all devices to work seamlessly with the tool. 🍻🍻🍻


### PR DESCRIPTION
There is now a folder named "Drivers" added to the Images partition - place any required drivers there and they will now bootstrap before any user input is required.

This should fix issues with Surface Pro devices and any other devices with weird driver requirements.